### PR TITLE
More types; more lattices

### DIFF
--- a/Ward.cabal
+++ b/Ward.cabal
@@ -26,7 +26,7 @@ executable ward
   build-depends:       base
                      , array
                      , bytestring
-                     , containers
+                     , containers >= 0.5.8
                      , deepseq
                      , filepath
                      , hashable
@@ -58,7 +58,7 @@ test-suite test
                      , HUnit
                      , array
                      , bytestring
-                     , containers
+                     , containers >= 0.5.8
                      , deepseq
                      , hashable
                      , hspec

--- a/Ward.cabal
+++ b/Ward.cabal
@@ -15,7 +15,8 @@ cabal-version:       >=1.10
 executable ward
   hs-source-dirs:      src
   main-is:             Main.hs
-  other-modules:       Args
+  other-modules:       Algebra.Algebra
+                     , Args
                      , Check.Permissions
                      , Config
                      , DumpCallMap
@@ -46,7 +47,8 @@ test-suite test
   type:                exitcode-stdio-1.0
   hs-source-dirs:      src, test
   main-is:             Spec.hs
-  other-modules:       Args
+  other-modules:       Algebra.Algebra
+                     , Args
                      , Check.Permissions
                      , Config
                      , DumpCallMap

--- a/src/Algebra/Algebra.hs
+++ b/src/Algebra/Algebra.hs
@@ -1,0 +1,175 @@
+-- | Some order theory classes
+--
+-- This module should really re-export everything from
+-- https://hackage.haskell.org/package/lattices but this is just an experiment
+-- for now, so roll our own but in a compatible way (ie, one day this whole
+-- file should go away and just export Algebra.PartialOrd and Algebra.Lattice)
+module Algebra.Algebra (
+  -- * Partial Orders
+  PartialOrd (..)
+  -- * Semilattices
+  , JoinSemiLattice (..)
+  , joinLeq
+  , BoundedJoinSemiLattice (..)
+  , MeetSemiLattice (..)
+  , meetLeq
+  -- * Monoid wrappers
+  , Join(..)
+  ) where
+
+import Data.Hashable (Hashable)
+import qualified Data.HashMap.Strict as HashMap
+import qualified Data.HashSet as HashSet
+import qualified Data.Set as Set
+import qualified Data.Map as Map
+
+-- | A partial ordering on sets is a set equipped with a binary relation 'leq' that obeys
+-- the following laws
+--
+-- * Reflexivity: @a `leq` a@
+-- * Antisymmetry: @if (a `leq` b && b `leq` a) then a == b else True@
+-- * Transitivity: @if a ``leq`` b && b ``leq`` c then a ``leq`` c else True@
+--
+class Eq a => PartialOrd a where
+  -- | @a `leq` b@ returns 'True' if @a@ is less than or equal to @b@ in the
+  -- partial ordering.  Note that @not (a `leq` b)@ is not the same as @b `leq`
+  -- a@ - that is only the case if the two elements are 'comparable'.  In
+  -- general two arbitrary elements in a partial order need not be comparable.
+  leq :: a -> a -> Bool
+  -- | Two elements are comparable if @a `leq` b \\\/ b `leq` a@
+  comparable :: a -> a -> Bool
+  comparable a b = a `leq` b || b `leq` a
+  {-# MINIMAL leq #-}
+  
+instance PartialOrd () where
+  () `leq` () = True
+
+-- | The pointwise ordering on pairs: @(a,b) `leq` (a',b')@ iff @a `leq` a'@ and @b `leq` b'@
+instance (PartialOrd a, PartialOrd b) => PartialOrd (a,b) where
+  (a,b) `leq` (a', b') = a `leq` a' && b `leq` b'
+
+-- | The pointwise ordering on 3-tuples
+instance (PartialOrd a, PartialOrd b, PartialOrd c) => PartialOrd (a,b,c) where
+  (a,b,c) `leq` (a',b',c') = a `leq` a' && b `leq` b' && c `leq` c'
+
+-- | The subset ordering on sets - individual elements are not compared
+instance Ord a => PartialOrd (Set.Set a) where
+  leq = Set.isSubsetOf
+
+-- | The subset ordering on the keys of the map with values ordered pointwise.
+-- @Map.fromList [("a", 1)] `leq` Map.fromList [("a", 2), ("b", 3)]@ but not
+-- @Map.fromList [("a", 4)] `leq` Map.fromList [("a", 2), ("b", 3)]@ and not
+-- @Map.fromList [("a", 1), ("c", 5)] `leq` Map.fromList [("a", 2), ("b", 3)]@.
+instance (Ord k, PartialOrd v) => PartialOrd (Map.Map k v) where
+  leq = Map.isSubmapOfBy leq
+
+-- | A join semilattice is a set equipped with a binary operation ('\/') subject to
+--
+-- * Idempotency: @x \\\/ x == x@
+-- * Associativity: @ x \\\/ (y \\\/ z) == (x \\\/ y) \\\/ z @
+-- * Commutativity: @ x \\\/ y == y \\\/ x @
+class JoinSemiLattice a where
+  (\/) :: a -> a -> a
+  
+instance JoinSemiLattice () where
+  () \/ () = ()
+
+-- | The product of two join semilattices is another join semilattice where the
+-- joins are performed pointwise
+instance (JoinSemiLattice a, JoinSemiLattice b) => JoinSemiLattice (a, b) where
+  (a,b) \/ (a', b') = (a \/ a', b \/ b')
+
+-- | The product of three join semilattices is another join semilattice where the
+-- joins are performed pointwise
+instance (JoinSemiLattice a, JoinSemiLattice b, JoinSemiLattice c) => JoinSemiLattice (a, b, c) where
+  (a,b,c) \/ (a', b', c') = (a \/ a', b \/ b', c \/ c')
+
+instance Ord a => JoinSemiLattice (Set.Set a) where
+  (\/) = Set.union
+
+instance (Eq a, Hashable a) => JoinSemiLattice (HashSet.HashSet a) where
+  (\/) = HashSet.union
+
+instance (Eq k, Hashable k, JoinSemiLattice a) => JoinSemiLattice (HashMap.HashMap k a) where
+  (\/) = HashMap.unionWith (\/)
+
+-- | A meet semilattice is a set equipped with a binary operation ('/\') subject to
+--
+-- * Idempotency: @x \/\\ x == x@
+-- * Associativity: @ x \/\\ (y \/\\ z) == (x \/\\ y) \/\\ z @
+-- * Commutativity: @ x \/\\ y = y \/\\ x @
+class MeetSemiLattice a where
+  (/\) :: a -> a -> a
+
+instance MeetSemiLattice () where
+  () /\ () = ()
+
+instance (MeetSemiLattice a, MeetSemiLattice b) => MeetSemiLattice (a,b) where
+  (a,b) /\ (a',b') = (a /\ a', b /\ b')
+  
+instance (MeetSemiLattice a, MeetSemiLattice b, MeetSemiLattice c) => MeetSemiLattice (a,b,c) where
+  (a,b,c) /\ (a',b',c') = (a /\ a', b /\ b', c /\ c')
+
+instance Ord a => MeetSemiLattice (Set.Set a) where
+  (/\) = Set.intersection
+
+instance (Eq a, Hashable a) => MeetSemiLattice (HashSet.HashSet a) where
+  (/\) = HashSet.intersection
+
+instance (Eq k, Hashable k, MeetSemiLattice a) => MeetSemiLattice (HashMap.HashMap k a) where
+  (/\) = HashMap.intersectionWith (/\)
+
+-- | A bounded join semilattice has a distinguished element 'bottom' subject to
+--
+-- * Identity: @x \/ bottom == x@
+class JoinSemiLattice a => BoundedJoinSemiLattice a where
+  bottom :: a
+
+instance BoundedJoinSemiLattice () where
+  bottom = ()
+
+instance (BoundedJoinSemiLattice a, BoundedJoinSemiLattice b) => BoundedJoinSemiLattice (a, b) where
+  bottom = (bottom, bottom)
+
+instance (BoundedJoinSemiLattice a, BoundedJoinSemiLattice b, BoundedJoinSemiLattice c) => BoundedJoinSemiLattice (a, b, c) where
+  bottom = (bottom, bottom, bottom)
+
+instance (Eq k, Hashable k, JoinSemiLattice a) => BoundedJoinSemiLattice (HashMap.HashMap k a) where
+  bottom = HashMap.empty
+
+-- | Monoid wrapper for 'JoinSemiLattice'
+newtype Join a = Join { getJoin :: a }
+  deriving (Bounded, Eq, Ord)
+
+instance Functor Join where
+  fmap f = Join . f . getJoin
+
+instance Applicative Join where
+  pure = Join
+  mf <*> mx = Join (getJoin mf $ getJoin mx)
+
+instance Monad Join where
+  return = pure
+  mx >>= mf = mf (getJoin mx)
+
+instance Foldable Join where
+  foldMap f = f . getJoin
+
+instance Traversable Join where
+  traverse f = fmap Join . f . getJoin
+
+instance BoundedJoinSemiLattice a => Monoid (Join a) where
+  mempty = Join bottom
+  (Join a) `mappend` (Join b) = Join (a \/ b)
+
+-- | An implementation of 'leq' induced by ('\/')
+--
+-- @a `leq` b = a \/ b == b@
+joinLeq :: (Eq a, JoinSemiLattice a) => a -> a -> Bool
+joinLeq a b = a \/ b == b
+
+-- | An implementation of 'leq' induced by ('/\')
+--
+-- @a `leq` b = a /\ b == a@
+meetLeq :: (Eq a, MeetSemiLattice a) => a -> a -> Bool
+meetLeq a b = a /\ b == a

--- a/src/Check/Permissions.hs
+++ b/src/Check/Permissions.hs
@@ -61,8 +61,8 @@ data Node = Node
   -- by annotations, and updated as permissions are propagated.
     nodePermissions :: !(IORef PermissionActionSet)
 
-  -- | The annotated permission actions of the function.
-  , nodeAnnotations :: !(IORef PermissionActionSet)
+  -- | The initial annotated permission actions of the function.
+  , nodeAnnotations :: !PermissionActionSet
 
   -- | The callees of this function.
   , nodeCalls :: !(CallSequence FunctionName)
@@ -566,16 +566,10 @@ reportSCC implicitPermissions requiredAnnotations restrictions graphLookup scc =
         name = nodeName node
         pos = nodePos node
         requiredPermissions = lookup name requiredAnnotations
+        annotations = nodeAnnotations node
       do
-        (annotations, permissions) <- liftIO $ do
-          a <- readIORef $ nodeAnnotations node
-          p <- readIORef $ nodePermissions node
-          return (a,p)
-        reportDefinition
-          implicitPermissions
-          restrictions
-          requiredPermissions
-          (annotations, permissions, name, pos)
+        permissions <- liftIO $ readIORef $ nodePermissions node
+        reportDefinition implicitPermissions restrictions requiredPermissions (annotations, permissions, name, pos)
       do
         sites <- liftIO $ fmap Vector.toList $ Vector.freeze $ nodeSites node
         reportCallSites restrictions (sites, nodeCalls node, name, pos)
@@ -705,9 +699,9 @@ edgesFromFunctions functions = do
   for_ functions $ \ function -> do
     let name = functionName function
     permissions <- newIORef $ functionPermissions function
-    annotations <- newIORef $ functionPermissions function
     sites <- IOVector.replicate (callTreeBreadth (functionCalls function) + 1) bottom
     let
+      annotations = functionPermissions function
       node =
         ( Node
           { nodePermissions = permissions

--- a/src/Check/Permissions.hs
+++ b/src/Check/Permissions.hs
@@ -370,17 +370,29 @@ propagatePermissionsNode graphLookup (node, newInitialSite, name, callVertices) 
         -- Next, we infer information about permissions at each call site in the
         -- function by traversing its call tree.
         let
-          processCallTree
-            :: CallTree (Maybe Graph.Vertex)  -- input
-            -> Int                            -- offset within current sequence
-            -> IOVector Site                  -- current sequence
-            -> IO ()
 
-          processCallTree (Choice a b) i v = do
+        -- We start processing the call tree from the root, filling in the list
+        -- of top-level call sites for the function.
+        processCallTree graphLookup callVertices 0 sites
+
+        initial <- IOVector.read sites 0
+        final <- IOVector.read sites (IOVector.length sites - 1)
+        permissionsFromCallSites (nodePermissions node) (initial, final)
+
+
+-- | Given a call tree and the permission presence set at the current site (as
+-- an index into a vector of sites), update the current site and the following one
+-- with the new permission presence set.
+processCallTree :: (Graph.Vertex -> (Node, t1, t)) -- graphLookup
+                -> CallTree (Maybe Graph.Vertex)   -- input
+                -> Int                             -- offset within current sequence
+                -> IOVector Site                   -- current sequence
+                -> IO ()
+processCallTree graphLookup (Choice a b) i v = do
             callsA <- IOVector.replicate (callTreeBreadth a + 1) mempty
             callsB <- IOVector.replicate (callTreeBreadth b + 1) mempty
-            processCallTree a 0 callsA
-            processCallTree b 0 callsB
+            processCallTree graphLookup a 0 callsA
+            processCallTree graphLookup b 0 callsB
             beforeA <- IOVector.read callsA 0
             afterA <- IOVector.read callsA (IOVector.length callsA - 1)
             beforeB <- IOVector.read callsB 0
@@ -388,9 +400,9 @@ propagatePermissionsNode graphLookup (node, newInitialSite, name, callVertices) 
             IOVector.write v i (beforeA <> beforeB)
             IOVector.write v (succ i) (afterA <> afterB)
 
-          processCallTree s@(Sequence a b) i v = do
-            processCallTree a i v
-            processCallTree b (i + callTreeBreadth a) v
+processCallTree graphLookup s@(Sequence a b) i v = do
+            processCallTree graphLookup a i v
+            processCallTree graphLookup b (i + callTreeBreadth a) v
 
             -- Once we've collected permission information for each call site
             -- and propagated it forward, we propagate all /non-conflicting/
@@ -413,7 +425,7 @@ propagatePermissionsNode graphLookup (node, newInitialSite, name, callVertices) 
                     $ map presencePermission
                     $ HashSet.toList before)
 
-          processCallTree (Call (Just call)) i v = do
+processCallTree graphLookup (Call (Just call)) i v = do
             let (Node { nodePermissions = callPermissionsRef }, callName, _) = graphLookup call
             callPermissions <- readIORef callPermissionsRef
 
@@ -493,19 +505,11 @@ propagatePermissionsNode graphLookup (node, newInitialSite, name, callVertices) 
                 -- FIXME: Verify this.
                 Waive{} -> pure ()
 
-          -- Assume an unknown call has irrelevant permissions. I just know this
-          -- is going to bite me later.
-          processCallTree (Call Nothing) _ _ = pure ()
-          processCallTree Nop _ _ = pure ()
-
-        -- We start processing the call tree from the root, filling in the list
-        -- of top-level call sites for the function.
-        processCallTree callVertices 0 sites
-
-        initial <- IOVector.read sites 0
-        final <- IOVector.read sites (IOVector.length sites - 1)
-        permissionsFromCallSites (nodePermissions node) (initial, final)
-
+processCallTree _ (Call Nothing) _ _ =
+                -- Assume an unknown call has irrelevant permissions. I just know this
+                -- is going to bite me later.
+                pure ()
+processCallTree _ Nop _ _ = pure ()
 
 -- After processing a call tree, we can infer its permission actions
 -- based on the permissions in the first and last call sites.

--- a/src/Check/Permissions.hs
+++ b/src/Check/Permissions.hs
@@ -10,6 +10,7 @@ module Check.Permissions
   , validatePermissions
   ) where
 
+import Algebra.Algebra
 import Config
 import Control.Monad (unless, when)
 import Control.Monad.IO.Class (liftIO)
@@ -27,6 +28,7 @@ import Language.C.Data.Node (NodeInfo, posOfNode)
 import Language.C.Data.Position (posFile)
 import Types
 import qualified Data.Graph as Graph
+import qualified Data.HashMap.Strict as HashMap
 import qualified Data.HashSet as HashSet
 import qualified Data.Map as Map
 import qualified Data.Text as Text
@@ -266,7 +268,7 @@ process functions config = do
 
     restrictions =
       [ Restriction
-        { restCondition = Uses name
+        { restName = name
         , restExpression = expr
         , restDescription = desc
         }
@@ -365,7 +367,7 @@ propagatePermissionsNode graphLookup (node, newInitialSite, name, callVertices) 
 
         -- We initialize the first call site of the function according to its
         -- permission actions.
-        IOVector.modify sites (\old -> old <> newInitialSite) 0
+        IOVector.modify sites (\old -> old \/ newInitialSite) 0
 
         -- Next, we infer information about permissions at each call site in the
         -- function by traversing its call tree.
@@ -392,7 +394,7 @@ processCallSequence graphLookup s i v =
             processCallSequence graphLookup b (succ i) v
 
             -- Once we've collected permission information for each call site
-            -- and propagated it forward, we propagate all /non-conflicting/
+            -- and propagated it forward, we propagate all new or /newly-conflicting/
             -- information /backward/ through the whole sequence; this has the
             -- effect of filling in the 0th call site (before the first call) in
             -- a function with any relevant permissions from the body of the
@@ -408,11 +410,13 @@ processCallSequence graphLookup s i v =
               for_ (reverse [1 .. IOVector.length v - 1]) $ \ statement -> do
                 after <- IOVector.read v statement
                 flip (IOVector.modify v) (pred statement) $ \ before
-                  -> before <> (foldr HashSet.delete after
-                    $ concatMap (\p -> [Has p, Lacks p, Uses p])
-                    $ map presencePermission
-                    $ HashSet.toList before)
+                  -> before \/ permissionDiff after before
     Nothing -> pure ()
+  where
+    permissionDiff (PermissionPresenceSet x) (PermissionPresenceSet y) =
+      PermissionPresenceSet (HashMap.differenceWith keepConflicting x y)
+    keepConflicting pafter _pbefore =
+      if conflicting pafter then Just pafter else Nothing
 
 -- | Given a call tree and the permission presence set at the current site (as
 -- an index into a vector of sites), update the current site and the following one
@@ -423,27 +427,26 @@ processCallTree :: (Graph.Vertex -> (Node, t1, t)) -- graphLookup
                 -> IOVector Site                   -- current sequence
                 -> IO ()
 processCallTree graphLookup (Choice a b) i v = do
-            callsA <- IOVector.replicate (callTreeBreadth a + 1) mempty
-            callsB <- IOVector.replicate (callTreeBreadth b + 1) mempty
+            callsA <- IOVector.replicate (callTreeBreadth a + 1) bottom
+            callsB <- IOVector.replicate (callTreeBreadth b + 1) bottom
             processCallSequence graphLookup a 0 callsA
             processCallSequence graphLookup b 0 callsB
             beforeA <- IOVector.read callsA 0
             afterA <- IOVector.read callsA (IOVector.length callsA - 1)
             beforeB <- IOVector.read callsB 0
             afterB <- IOVector.read callsB (IOVector.length callsB - 1)
-            IOVector.write v i (beforeA <> beforeB)
-            IOVector.write v (succ i) (afterA <> afterB)
+            IOVector.write v i (beforeA \/ beforeB)
+            IOVector.write v (succ i) (afterA \/ afterB)
 
 processCallTree graphLookup (Call (Just call)) i v = do
             let (Node { nodePermissions = callPermissionsRef }, callName, _) = graphLookup call
             callPermissions <- readIORef callPermissionsRef
 
-            -- We propagate non-conflicting permissions forward in the call tree
+            -- We propagate permissions forward in the call tree
             -- at each step. This ensures that the /final/ call site (after the
             -- last call) contains relevant permissions from the body of the
             -- function.
             IOVector.write v (succ i)
-              . HashSet.filter (not . conflicting)
               =<< IOVector.read v i
 
             -- Update permission presence (has/lacks/conflicts) according to
@@ -466,7 +469,7 @@ processCallTree _ (Call Nothing) _ _ =
 -- if some permission is irrelevant to a particular call, it just
 -- passes on through.
 permissionsPresenceFromCalleeActions :: Int
-                                     -> IOVector (HashSet.HashSet PermissionPresence)
+                                     -> IOVector Site
                                      -> PermissionAction
                                      -> IO ()
 permissionsPresenceFromCalleeActions i v callPermission = do
@@ -476,20 +479,11 @@ permissionsPresenceFromCalleeActions i v callPermission = do
                 -- must have (lack) it. If the call site already lacks (has) it,
                 -- we record the conflict.
 
-                Need p -> do
-                  if Lacks p `HashSet.member` current
-                    then ((<> site (Conflicts p)) . HashSet.delete (Lacks p)) current
-                    else (<> site (Has p)) current
+                Need p -> current \/ singletonPresence p has
 
-                Use p -> do
-                  if Lacks p `HashSet.member` current
-                    then ((<> site (Conflicts p)) . HashSet.delete (Lacks p)) current
-                    else (<> HashSet.fromList [Has p, Uses p]) current
+                Use p -> current \/ singletonPresence p (has \/ uses)
 
-                Deny p -> do
-                  if Has p `HashSet.member` current
-                    then ((<> site (Conflicts p)) . HashSet.delete (Has p) . HashSet.delete (Uses p)) current
-                    else ((<> site (Lacks p))) current
+                Deny p -> current \/ singletonPresence p lacks -- FIXME: drop use of p if p is a conflict
 
                 -- If a call grants (resp. revokes) a permission, its call site
                 -- must lack (have) it, and the following call site must have
@@ -498,22 +492,28 @@ permissionsPresenceFromCalleeActions i v callPermission = do
                 -- already lacks (has) it, we replace it to reflect the change
                 -- in permission state.
 
-                Grant p -> do
-                  if Has p `HashSet.member` current
-                    then ((<> site (Conflicts p)) . HashSet.delete (Has p) . HashSet.delete (Uses p)) current
-                    else ((<> site (Lacks p))) current
+                Grant p ->
+                  current \/ singletonPresence p lacks -- FIXME: drop use of p if p is a conflict
 
-                Revoke p -> do
-                  if Lacks p `HashSet.member` current
-                    then ((<> site (Conflicts p)) . HashSet.delete (Lacks p)) current
-                    else ((<> site (Has p))) current
+                Revoke p -> current \/ singletonPresence p has
 
                 -- FIXME: Verify this.
                 Waive{} -> current
   flip (IOVector.modify v) (succ i) $ case callPermission of
-    Grant p -> ((<> site (Has p)) . HashSet.delete (Lacks p))
-    Revoke p -> ((<> site (Lacks p)) . HashSet.delete (Has p) . HashSet.delete (Uses p))
+    Grant p -> strongUpdateCap p CapHas Uses
+    Revoke p -> strongUpdateCap p CapLacks UsageUnknown
     _ -> id
+
+strongUpdateCap :: PermissionName -> Capability -> Usage -> PermissionPresenceSet -> PermissionPresenceSet
+strongUpdateCap pn cap usageUB =
+  PermissionPresenceSet . HashMap.alter alteration pn . unPermissionPresenceSet
+  where
+    alteration mold =
+      let
+        usage = usageUB /\ case mold of
+                  Nothing -> bottom
+                  Just old -> presenceUsage old
+      in Just $ PermissionPresence usage cap
 
 -- After processing a call tree, we can infer its permission actions
 -- based on the permissions in the first and last call sites.
@@ -524,8 +524,7 @@ permissionsFromCallSites permissionRef initialFinal@(initial, final) = do
 
             -- For each "relevant" permission P in first & last call sites:
             let
-              relevantPermissions = nub $ map presencePermission
-                $ HashSet.toList initial <> HashSet.toList final
+              relevantPermissions = presenceKeys (initial \/ final)
 
             let
               derivedActions = HashSet.fromList $ mconcat $ map (derivePermissionActions initialFinal) relevantPermissions
@@ -551,14 +550,14 @@ derivePermissionActions (initial,final) p =
     -- (NB. The seemingly redundant side conditions here prevent spurious
     -- error messages from inconsistent permissions.)
     needsRevokes =
-      if (Has p `HashSet.member` initial && not (Lacks p `HashSet.member` initial))
+      if (has `leq` lookupPresence p initial && not (lacks `leq` lookupPresence p initial))
       then -- When the initial state has P, the function needs P.
         needs <> revokes
       else
         mempty
     grants =
-      if (Lacks p `HashSet.member` initial && not (Has p `HashSet.member` initial))
-         && (Has p `HashSet.member` final && not (Lacks p `HashSet.member` final))
+      if (lacks `leq` lookupPresence p initial && not (has `leq` lookupPresence p initial))
+         && (has `leq` lookupPresence p final && not (lacks `leq` lookupPresence p final))
       then
         -- When the initial state lacks P but the final state has P, the
         -- function grants P.
@@ -568,7 +567,7 @@ derivePermissionActions (initial,final) p =
 
     needs = [Need p]
     revokes =
-      if (Lacks p `HashSet.member` final && not (Has p `HashSet.member` final))
+      if (lacks `leq` lookupPresence p final && not (has `leq` lookupPresence p final))
       then 
         -- When the initial state has P, but the final state lacks P,
         -- the function revokes P.
@@ -693,12 +692,11 @@ reportCallSites :: [Restriction]
                 -> Logger ()
 reportCallSites restrictions (sites, callees, name, pos) = do
       -- Report call sites with conflicting information.
-      let conflicts = HashSet.filter conflicting $ mconcat sites
-      unless (HashSet.null conflicts) $ do
+      let conflicts = getJoin $ foldMap (Join . conflictingPresence) sites
+      unless (nullPresence conflicts) $ do
         record True $ Error pos $ Text.concat $
           [ "conflicting information for permissions "
-          , Text.pack $ show $ sort $ map presencePermission
-            $ HashSet.toList conflicts
+          , Text.pack $ show $ presenceKeys conflicts
           , " in '"
           , name
           , "'"
@@ -738,7 +736,7 @@ edgesFromFunctions functions = do
     let name = functionName function
     permissions <- newIORef $ functionPermissions function
     annotations <- newIORef $ functionPermissions function
-    sites <- IOVector.replicate (callTreeBreadth (functionCalls function) + 1) mempty
+    sites <- IOVector.replicate (callTreeBreadth (functionCalls function) + 1) bottom
     let
       node =
         ( Node
@@ -758,13 +756,12 @@ edgesFromFunctions functions = do
 -- | Evaluates a restriction in a context.
 evalRestriction :: PermissionPresenceSet -> Restriction -> Bool
 evalRestriction context restriction
-  | restCondition restriction `HashSet.member` context = go $ restExpression restriction
+  | uses `leq` lookupPresence (restName restriction) context = go $ restExpression restriction -- FIXME: what if the context lacks the given restriction or uses it? ignore?
   | otherwise = True
   where
     go = \ case
       -- Since 'Conflicts' represents both 'Has' and 'Lacks', it matches both.
-      Context p -> p `HashSet.member` context
-        || Conflicts (presencePermission p) `HashSet.member` context
+      Context pn pval -> pval `leq` lookupPresence pn context
       a `And` b -> go a && go b
       a `Or` b -> go a || go b
       Not a -> not $ go a
@@ -799,30 +796,29 @@ validatePermissions config =
 -- compute the permission presense available on entry to the function.
 initialSite :: [PermissionAction] -> Site
 initialSite =
-  foldMap $ \ permissionAction -> case permissionAction of
-  -- If a function needs or revokes a permission, then its first call
-  -- site must have that permission.
-  Need p -> site $ Has p
-  Use p -> site $ Uses p
-  Revoke p -> site $ Has p
+  getJoin . foldMap siteAction
+  where
+    siteAction :: PermissionAction -> Join Site
+    siteAction permissionAction = case permissionAction of
+      -- If a function needs or revokes a permission, then its first call
+      -- site must have that permission.
+      Need p -> site p has
+      Use p -> site p uses
+      Revoke p -> site p has
 
-  -- If a function grants or denies a permission, then its first call
-  -- site must lack that permission.
-  Grant p -> site $ Lacks p
-  Deny p -> site $ Lacks p
+      -- If a function grants or denies a permission, then its first call
+      -- site must lack that permission.
+      Grant p -> site p lacks
+      Deny p -> site p lacks
 
-  -- FIXME: Verify this.
-  Waive{} -> mempty
+      -- FIXME: Verify this.
+      Waive{} -> mempty
 
 -- | Convenience function for building call site info.
-site :: PermissionPresence -> Site
-site = HashSet.singleton
+site :: PermissionName -> PermissionPresence -> Join Site
+site pn = Join . singletonPresence pn
 
 -- | Convenience function to help type inference in message formatting.
 strConcat :: [String] -> String
 strConcat = concat
 
--- | Convenience function for testing whether we found a conflict.
-conflicting :: PermissionPresence -> Bool
-conflicting Conflicts{} = True
-conflicting _ = False

--- a/src/Check/Permissions.hs
+++ b/src/Check/Permissions.hs
@@ -19,7 +19,7 @@ import Data.Graph (Graph, graphFromEdges)
 import Data.IORef
 import Data.List (foldl', isSuffixOf, nub, sort)
 import Data.Maybe (fromMaybe)
-import Data.Monoid ((<>))
+import Data.Monoid ((<>), Any(..))
 import Data.These
 import Data.Vector.Mutable (IOVector)
 import Language.C.Data.Ident (Ident)
@@ -330,9 +330,9 @@ inferPermissionsSCC :: [PermissionName]
 inferPermissionsSCC implicitPermissions graphLookup graphVertex scc = do
     -- We continue processing until the SCC's permission information reaches a
     -- fixed point, i.e., we are no longer adding permission information.
-    growing <- newIORef True
+    growing <- newIORef mempty
     fix $ \ loop -> do
-      writeIORef growing False
+      writeIORef growing mempty
 
       -- For each function in the SCC:
       for_ scc $ \ vertex -> do
@@ -348,17 +348,17 @@ inferPermissionsSCC implicitPermissions graphLookup graphVertex scc = do
             ]
           nodePermissionActions = HashSet.toList permissionActions <> implicitPermissionActions
         nodeGrowing <- propagatePermissionsNode graphLookup (node, initialSite nodePermissionActions, name, graphVertex <$> nodeCalls node)
-        modifyIORef' growing (|| nodeGrowing)
+        modifyIORef' growing (<> nodeGrowing)
 
       -- We continue processing the current SCC if we're still propagating
       -- permission information between functions.
       do
         shouldContinue <- readIORef growing
-        if shouldContinue then loop else pure ()
+        if getAny shouldContinue then loop else pure ()
 
 propagatePermissionsNode :: (Graph.Vertex -> (Node, t1, t))
                        -> (Node, Site, FunctionName, CallTree (Maybe Graph.Vertex))
-                       -> IO Bool
+                       -> IO Any
 propagatePermissionsNode graphLookup (node, newInitialSite, name, callVertices) = do
         let
           sites = nodeSites node
@@ -509,7 +509,7 @@ propagatePermissionsNode graphLookup (node, newInitialSite, name, callVertices) 
 
 -- After processing a call tree, we can infer its permission actions
 -- based on the permissions in the first and last call sites.
-permissionsFromCallSites :: IORef PermissionActionSet -> (Site, Site) -> IO Bool
+permissionsFromCallSites :: IORef PermissionActionSet -> (Site, Site) -> IO Any
 permissionsFromCallSites permissionRef initialFinal@(initial, final) = do
             initialActions <- readIORef permissionRef
             let currentSize = HashSet.size initialActions
@@ -532,7 +532,7 @@ permissionsFromCallSites permissionRef initialFinal@(initial, final) = do
             -- fixed point.
             --
             -- TODO: Limit the number of iterations to prevent infinite loops.
-            pure $ modifiedSize > currentSize
+            pure $ Any $ modifiedSize > currentSize
 
 -- Given the initial and final call sites and a permission P, determine the action
 -- of the function with respect to P by considering its presence or absence at function entry and exit.

--- a/src/Check/Permissions.hs
+++ b/src/Check/Permissions.hs
@@ -36,10 +36,10 @@ import qualified Data.Vector.Mutable as IOVector
 
 -- | A function given as input to the permission checking algorithm.
 data Function = Function
-
+  {
   -- | The source location where the function was declared, or where it was
   -- defined if there was no declaration.
-  { functionPos :: !NodeInfo
+    functionPos :: !NodeInfo
 
   -- | The name of the function, prefixed with its file path if @static@.
   , functionName :: !FunctionName
@@ -54,10 +54,10 @@ data Function = Function
 -- | A node in the call graph, representing a function and information about
 -- permissions at each of its call sites.
 data Node = Node
-
+  {
   -- | The permission actions of the function. This is set in the initial state
   -- by annotations, and updated as permissions are propagated.
-  { nodePermissions :: !(IORef PermissionActionSet)
+    nodePermissions :: !(IORef PermissionActionSet)
 
   -- | The annotated permission actions of the function.
   , nodeAnnotations :: !(IORef PermissionActionSet)

--- a/src/Check/Permissions.hs
+++ b/src/Check/Permissions.hs
@@ -48,7 +48,7 @@ data Function = Function
   , functionPermissions :: !PermissionActionSet
 
   -- | A tree of callees of this function.
-  , functionCalls :: !(CallTree FunctionName)
+  , functionCalls :: !(CallSequence FunctionName)
   }
 
 -- | A node in the call graph, representing a function and information about
@@ -63,7 +63,7 @@ data Node = Node
   , nodeAnnotations :: !(IORef PermissionActionSet)
 
   -- | The callees of this function.
-  , nodeCalls :: !(CallTree FunctionName)
+  , nodeCalls :: !(CallSequence FunctionName)
 
   -- | One more than the number of callees, representing the permission state
   -- before and after each call.
@@ -357,7 +357,7 @@ inferPermissionsSCC implicitPermissions graphLookup graphVertex scc = do
         if getAny shouldContinue then loop else pure ()
 
 propagatePermissionsNode :: (Graph.Vertex -> (Node, t1, t))
-                       -> (Node, Site, FunctionName, CallTree (Maybe Graph.Vertex))
+                       -> (Node, Site, FunctionName, CallSequence (Maybe Graph.Vertex))
                        -> IO Any
 propagatePermissionsNode graphLookup (node, newInitialSite, name, callVertices) = do
         let
@@ -373,12 +373,46 @@ propagatePermissionsNode graphLookup (node, newInitialSite, name, callVertices) 
 
         -- We start processing the call tree from the root, filling in the list
         -- of top-level call sites for the function.
-        processCallTree graphLookup callVertices 0 sites
+        processCallSequence graphLookup callVertices 0 sites
 
         initial <- IOVector.read sites 0
         final <- IOVector.read sites (IOVector.length sites - 1)
         permissionsFromCallSites (nodePermissions node) (initial, final)
 
+
+processCallSequence :: (Graph.Vertex -> (Node, t1, t))
+                    -> CallSequence (Maybe Graph.Vertex)
+                    -> Int
+                    -> IOVector Site
+                    -> IO ()
+processCallSequence graphLookup s i v =
+  case viewlCallSequence s of
+    Just (a,b) -> do
+            processCallTree graphLookup a i v
+            processCallSequence graphLookup b (succ i) v
+
+            -- Once we've collected permission information for each call site
+            -- and propagated it forward, we propagate all /non-conflicting/
+            -- information /backward/ through the whole sequence; this has the
+            -- effect of filling in the 0th call site (before the first call) in
+            -- a function with any relevant permissions from the body of the
+            -- function.
+            --
+            -- FIXME: I think we could do this purely, because only the result
+            -- at index 0 should matter at this point.
+            --
+            -- FIXME: We also get hear when we're at the head of a Choice
+            -- (because it works in a copy of the vector), is this the right
+            -- thing to do there?
+            when (i == 0) $ do
+              for_ (reverse [1 .. IOVector.length v - 1]) $ \ statement -> do
+                after <- IOVector.read v statement
+                flip (IOVector.modify v) (pred statement) $ \ before
+                  -> before <> (foldr HashSet.delete after
+                    $ concatMap (\p -> [Has p, Lacks p, Uses p])
+                    $ map presencePermission
+                    $ HashSet.toList before)
+    Nothing -> pure ()
 
 -- | Given a call tree and the permission presence set at the current site (as
 -- an index into a vector of sites), update the current site and the following one
@@ -391,39 +425,14 @@ processCallTree :: (Graph.Vertex -> (Node, t1, t)) -- graphLookup
 processCallTree graphLookup (Choice a b) i v = do
             callsA <- IOVector.replicate (callTreeBreadth a + 1) mempty
             callsB <- IOVector.replicate (callTreeBreadth b + 1) mempty
-            processCallTree graphLookup a 0 callsA
-            processCallTree graphLookup b 0 callsB
+            processCallSequence graphLookup a 0 callsA
+            processCallSequence graphLookup b 0 callsB
             beforeA <- IOVector.read callsA 0
             afterA <- IOVector.read callsA (IOVector.length callsA - 1)
             beforeB <- IOVector.read callsB 0
             afterB <- IOVector.read callsB (IOVector.length callsB - 1)
             IOVector.write v i (beforeA <> beforeB)
             IOVector.write v (succ i) (afterA <> afterB)
-
-processCallTree graphLookup s@(Sequence a b) i v = do
-            processCallTree graphLookup a i v
-            processCallTree graphLookup b (i + callTreeBreadth a) v
-
-            -- Once we've collected permission information for each call site
-            -- and propagated it forward, we propagate all /non-conflicting/
-            -- information /backward/ through the whole sequence; this has the
-            -- effect of filling in the 0th call site (before the first call) in
-            -- a function with any relevant permissions from the body of the
-            -- function.
-            --
-            -- This assumes that 'Sequence's are right-associative, ensuring
-            -- we're at the root of a sequence if @i@ is @0@.
-            --
-            -- FIXME: I think we could do this purely, because only the result
-            -- at index 0 should matter at this point.
-            when (i == 0) $ do
-              for_ (reverse [1 .. IOVector.length v - 1]) $ \ statement -> do
-                after <- IOVector.read v statement
-                flip (IOVector.modify v) (pred statement) $ \ before
-                  -> before <> (foldr HashSet.delete after
-                    $ concatMap (\p -> [Has p, Lacks p, Uses p])
-                    $ map presencePermission
-                    $ HashSet.toList before)
 
 processCallTree graphLookup (Call (Just call)) i v = do
             let (Node { nodePermissions = callPermissionsRef }, callName, _) = graphLookup call
@@ -509,7 +518,7 @@ processCallTree _ (Call Nothing) _ _ =
                 -- Assume an unknown call has irrelevant permissions. I just know this
                 -- is going to bite me later.
                 pure ()
-processCallTree _ Nop _ _ = pure ()
+
 
 -- After processing a call tree, we can infer its permission actions
 -- based on the permissions in the first and last call sites.
@@ -685,7 +694,7 @@ reportDefinition implicitPermissions restrictions requiredPermissions (annotatio
 -- | Report violations at the calls in the given function due to
 -- callee functions with conflicting permissions or violated restrictions.
 reportCallSites :: [Restriction]
-                -> ([Site], CallTree FunctionName, FunctionName, NodeInfo)
+                -> ([Site], CallSequence FunctionName, FunctionName, NodeInfo)
                 -> Logger ()
 reportCallSites restrictions (sites, callees, name, pos) = do
       -- Report call sites with conflicting information.

--- a/src/Check/Permissions.hs
+++ b/src/Check/Permissions.hs
@@ -449,14 +449,27 @@ processCallTree graphLookup (Call (Just call)) i v = do
             -- Update permission presence (has/lacks/conflicts) according to
             -- permission actions (needs/denies/grants/revokes).
             --
-            -- Note how this works with the forward-propagation above: if a call
-            -- site grants or revokes a permission for which information was
-            -- propagated from the previous call site, the old information is
-            -- /replaced/ to indicate the change in permissions; it doesn't
-            -- generate a conflict unless there's actually conflicting info. And
-            -- if some permission is irrelevant to a particular call, it just
-            -- passes on through.
-            for_ (HashSet.toList callPermissions) $ \ callPermission -> do
+            for_ (HashSet.toList callPermissions) $ permissionsPresenceFromCalleeActions i v
+
+processCallTree _ (Call Nothing) _ _ =
+                -- Assume an unknown call has irrelevant permissions. I just know this
+                -- is going to bite me later.
+                pure ()
+
+
+
+-- Note how this works with the forward-propagation above: if a call
+-- site grants or revokes a permission for which information was
+-- propagated from the previous call site, the old information is
+-- /replaced/ to indicate the change in permissions; it doesn't
+-- generate a conflict unless there's actually conflicting info. And
+-- if some permission is irrelevant to a particular call, it just
+-- passes on through.
+permissionsPresenceFromCalleeActions :: Int
+                                     -> IOVector (HashSet.HashSet PermissionPresence)
+                                     -> PermissionAction
+                                     -> IO ()
+permissionsPresenceFromCalleeActions i v callPermission = do
               case callPermission of
 
                 -- If a call needs (resp. denies) a permission, its call site
@@ -513,12 +526,6 @@ processCallTree graphLookup (Call (Just call)) i v = do
 
                 -- FIXME: Verify this.
                 Waive{} -> pure ()
-
-processCallTree _ (Call Nothing) _ _ =
-                -- Assume an unknown call has irrelevant permissions. I just know this
-                -- is going to bite me later.
-                pure ()
-
 
 -- After processing a call tree, we can infer its permission actions
 -- based on the permissions in the first and last call sites.

--- a/src/Check/Permissions.hs
+++ b/src/Check/Permissions.hs
@@ -473,47 +473,17 @@ permissionsPresenceFromCalleeActions :: Int
                                      -> PermissionAction
                                      -> IO ()
 permissionsPresenceFromCalleeActions i v callPermission = do
-  flip (IOVector.modify v) i $ \current -> case callPermission of
+  flip (IOVector.modify v) i $ \current -> current \/ getJoin (actionPrecondition callPermission)
+  flip (IOVector.modify v) (succ i) $ strongUpdateCap callPermission
 
-                -- If a call needs (resp. denies) a permission, its call site
-                -- must have (lack) it. If the call site already lacks (has) it,
-                -- we record the conflict.
-
-                Need p -> current \/ singletonPresence p has
-
-                Use p -> current \/ singletonPresence p (has \/ uses)
-
-                Deny p -> current \/ singletonPresence p lacks -- FIXME: drop use of p if p is a conflict
-
-                -- If a call grants (resp. revokes) a permission, its call site
-                -- must lack (have) it, and the following call site must have
-                -- (lack) it. If the current call site already has (lacks) it,
-                -- we record the conflict. But if the following call site
-                -- already lacks (has) it, we replace it to reflect the change
-                -- in permission state.
-
-                Grant p ->
-                  current \/ singletonPresence p lacks -- FIXME: drop use of p if p is a conflict
-
-                Revoke p -> current \/ singletonPresence p has
-
-                -- FIXME: Verify this.
-                Waive{} -> current
-  flip (IOVector.modify v) (succ i) $ case callPermission of
-    Grant p -> strongUpdateCap p CapHas Uses
-    Revoke p -> strongUpdateCap p CapLacks UsageUnknown
-    _ -> id
-
-strongUpdateCap :: PermissionName -> Capability -> Usage -> PermissionPresenceSet -> PermissionPresenceSet
-strongUpdateCap pn cap usageUB =
-  PermissionPresenceSet . HashMap.alter alteration pn . unPermissionPresenceSet
+strongUpdateCap :: PermissionAction -> PermissionPresenceSet -> PermissionPresenceSet
+strongUpdateCap act =
+  let
+    pn = permissionActionName act
+  in modifyPresence pn update
   where
-    alteration mold =
-      let
-        usage = usageUB /\ case mold of
-                  Nothing -> bottom
-                  Just old -> presenceUsage old
-      in Just $ PermissionPresence usage cap
+    (j, m) = actionPostcondition act
+    update old = (old /\ m) \/ j
 
 -- After processing a call tree, we can infer its permission actions
 -- based on the permissions in the first and last call sites.
@@ -796,23 +766,33 @@ validatePermissions config =
 -- compute the permission presense available on entry to the function.
 initialSite :: [PermissionAction] -> Site
 initialSite =
-  getJoin . foldMap siteAction
+  getJoin . foldMap actionPrecondition
+
+-- | Given the permission action of a call, return
+-- the permission presence that must be true /prior/ to the call.
+--
+-- If a call needs, uses or revokes a permission, then it must have that
+-- permission prior to the call.  (And if it uses it, it must indicate
+-- that too).
+-- If a call grants or denies a permission, then it must lack it prior to the call
+actionPrecondition :: PermissionAction -> Join Site
+actionPrecondition (Need p) = site p has
+actionPrecondition (Use p) = site p (uses \/ has)
+actionPrecondition (Revoke p) = site p has
+actionPrecondition (Deny p) = site p lacks -- fixme: caller should drop use of p if the join results in a conflict
+actionPrecondition (Grant p) = site p lacks -- fixme: caller should drop use of p if the join results in a conflic
+actionPrecondition (Waive _p) = mempty
+
+-- returns a pair (j, m) where the previous permission presense x will be modified to (x /\ m) \/ j.
+-- so m should be top for a no-op, and j should be bottom for a no-op.
+actionPostcondition :: PermissionAction -> (PermissionPresence, PermissionPresence)
+actionPostcondition p =
+  case p of
+    Grant {} -> (has, uses) -- drop previous cap, keep usage, add Has
+    Revoke {} -> (lacks, bottom) -- deletes previous cap and use, add Lacks
+    _ -> (bottom, top) -- keep everything unchanged
   where
-    siteAction :: PermissionAction -> Join Site
-    siteAction permissionAction = case permissionAction of
-      -- If a function needs or revokes a permission, then its first call
-      -- site must have that permission.
-      Need p -> site p has
-      Use p -> site p uses
-      Revoke p -> site p has
-
-      -- If a function grants or denies a permission, then its first call
-      -- site must lack that permission.
-      Grant p -> site p lacks
-      Deny p -> site p lacks
-
-      -- FIXME: Verify this.
-      Waive{} -> mempty
+    top = uses \/ conflicts
 
 -- | Convenience function for building call site info.
 site :: PermissionName -> PermissionPresence -> Join Site

--- a/src/Check/Permissions.hs
+++ b/src/Check/Permissions.hs
@@ -470,32 +470,26 @@ permissionsPresenceFromCalleeActions :: Int
                                      -> PermissionAction
                                      -> IO ()
 permissionsPresenceFromCalleeActions i v callPermission = do
-              case callPermission of
+  flip (IOVector.modify v) i $ \current -> case callPermission of
 
                 -- If a call needs (resp. denies) a permission, its call site
                 -- must have (lack) it. If the call site already lacks (has) it,
                 -- we record the conflict.
 
                 Need p -> do
-                  current <- IOVector.read v i
                   if Lacks p `HashSet.member` current
-                    then IOVector.modify v ((<> site (Conflicts p)) . HashSet.delete (Lacks p)) i
-                    else IOVector.modify v (<> site (Has p)) i
+                    then ((<> site (Conflicts p)) . HashSet.delete (Lacks p)) current
+                    else (<> site (Has p)) current
 
                 Use p -> do
-                  current <- IOVector.read v i
                   if Lacks p `HashSet.member` current
-                    then IOVector.modify v ((<> site (Conflicts p)) . HashSet.delete (Lacks p)) i
-                    else IOVector.modify v (<> HashSet.fromList [Has p, Uses p]) i
+                    then ((<> site (Conflicts p)) . HashSet.delete (Lacks p)) current
+                    else (<> HashSet.fromList [Has p, Uses p]) current
 
                 Deny p -> do
-                  current <- IOVector.read v i
                   if Has p `HashSet.member` current
-                    then IOVector.modify v
-                      ((<> site (Conflicts p))
-                        . HashSet.delete (Has p)
-                        . HashSet.delete (Uses p)) i
-                    else IOVector.modify v ((<> site (Lacks p))) i
+                    then ((<> site (Conflicts p)) . HashSet.delete (Has p) . HashSet.delete (Uses p)) current
+                    else ((<> site (Lacks p))) current
 
                 -- If a call grants (resp. revokes) a permission, its call site
                 -- must lack (have) it, and the following call site must have
@@ -505,27 +499,21 @@ permissionsPresenceFromCalleeActions i v callPermission = do
                 -- in permission state.
 
                 Grant p -> do
-                  current <- IOVector.read v i
                   if Has p `HashSet.member` current
-                    then IOVector.modify v
-                      ((<> site (Conflicts p))
-                        . HashSet.delete (Has p)
-                        . HashSet.delete (Uses p)) i
-                    else IOVector.modify v ((<> site (Lacks p))) i
-                  IOVector.modify v ((<> site (Has p)) . HashSet.delete (Lacks p)) $ succ i
+                    then ((<> site (Conflicts p)) . HashSet.delete (Has p) . HashSet.delete (Uses p)) current
+                    else ((<> site (Lacks p))) current
 
                 Revoke p -> do
-                  current <- IOVector.read v i
                   if Lacks p `HashSet.member` current
-                    then IOVector.modify v ((<> site (Conflicts p)) . HashSet.delete (Lacks p)) i
-                    else IOVector.modify v ((<> site (Has p))) i
-                  IOVector.modify v
-                    ((<> site (Lacks p))
-                      . HashSet.delete (Has p)
-                      . HashSet.delete (Uses p)) $ succ i
+                    then ((<> site (Conflicts p)) . HashSet.delete (Lacks p)) current
+                    else ((<> site (Has p))) current
 
                 -- FIXME: Verify this.
-                Waive{} -> pure ()
+                Waive{} -> current
+  flip (IOVector.modify v) (succ i) $ case callPermission of
+    Grant p -> ((<> site (Has p)) . HashSet.delete (Lacks p))
+    Revoke p -> ((<> site (Lacks p)) . HashSet.delete (Has p) . HashSet.delete (Uses p))
+    _ -> id
 
 -- After processing a call tree, we can infer its permission actions
 -- based on the permissions in the first and last call sites.

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -7,7 +7,7 @@ module Config
 
 import Control.Monad (mzero, void)
 import Data.Either
-import Data.Monoid -- *
+import Data.Monoid -- \*
 import Data.These
 import Text.Parsec
 import Text.Parsec.String

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -76,7 +76,7 @@ expression = orExpression
     orExpression = foldr1 Or <$> andExpression `sepBy1` operator '|'
     andExpression = foldr1 And <$> term `sepBy1` operator '&'
     term = choice
-      [ Context . Has <$> permission
+      [ Context <$> permission <*> pure has
       , Not <$> (operator '!' *> term)
       , parenthesized expression
       ]

--- a/src/DumpCallMap.hs
+++ b/src/DumpCallMap.hs
@@ -13,10 +13,11 @@ import Control.Monad.IO.Class (MonadIO(..))
 
 import qualified Data.ByteString.Builder as B
 import Data.Foldable
-import qualified Data.Map as Map
 import Data.List (intersperse)
+import qualified Data.Map as Map
 import Data.Monoid (Monoid(..), (<>))
 import qualified Data.Text.Encoding as DTE
+import qualified Data.Sequence as Sequence
 import System.IO (Handle, hFlush)
 
 import Language.C.Data.Ident (Ident, identToString)
@@ -125,7 +126,7 @@ encodeCallTree enc = goSeqForest
     -- as long as t is a Nop or Sequence output as is, otherwise output a new
     -- form.
     goSeqForest :: CallSequence a -> B.Builder
-    goSeqForest (CallSequence ts) = mconcat $ intersperse newline (map goTree ts)
+    goSeqForest (CallSequence ts) = fold $ Sequence.intersperse newline (fmap goTree ts)
     goSeq :: CallSequence a -> B.Builder
     goSeq = form "seq" True . goSeqForest
     goTree :: CallTree a -> B.Builder

--- a/src/DumpCallMap.hs
+++ b/src/DumpCallMap.hs
@@ -3,6 +3,7 @@ module DumpCallMap (encodeCallMap, hPutCallMap) where
 
 import Types (CallMap
              , CallTree(..)
+             , CallSequence(..)
              , PermissionAction(..)
              , PermissionActionSet
              , PermissionName(..)
@@ -24,7 +25,7 @@ import Language.C.Data.Name (Name)
 import qualified Language.C.Data.Node as Node
 import qualified Language.C.Data.Position as Pos
 
-type CallMapItem = (NodeInfo, CallTree Ident, PermissionActionSet)
+type CallMapItem = (NodeInfo, CallSequence Ident, PermissionActionSet)
 
 -- | Encode the given callmap as a "Data.ByteString
 encodeCallMap :: CallMap -> B.Builder
@@ -118,21 +119,19 @@ encodeSourcePos p =
       ]
   in form "source" False $ mconcat $ intersperse space body
 
-encodeCallTree :: forall a . (a -> B.Builder) -> CallTree a -> B.Builder
-encodeCallTree enc = goSeq
+encodeCallTree :: forall a . (a -> B.Builder) -> CallSequence a -> B.Builder
+encodeCallTree enc = goSeqForest
   where
     -- as long as t is a Nop or Sequence output as is, otherwise output a new
     -- form.
-    goSeq :: CallTree a -> B.Builder
-    goSeq t = case t of
-      Nop -> mempty
-      Sequence t1 t2 -> go t1 <> newline <> goSeq t2
-      _ -> go t
-    go :: CallTree a -> B.Builder
-    go t = case t of
-      Choice t1 t2 -> form "choice" True (go t1 <> newline <> go t2)
+    goSeqForest :: CallSequence a -> B.Builder
+    goSeqForest (CallSequence ts) = mconcat $ intersperse newline (map goTree ts)
+    goSeq :: CallSequence a -> B.Builder
+    goSeq = form "seq" True . goSeqForest
+    goTree :: CallTree a -> B.Builder
+    goTree t = case t of
+      Choice t1 t2 -> form "choice" True (goSeq t1 <> newline <> goSeq t2)
       Call c -> form "call" False (enc c)
-      _ -> form "seq" True (goSeq t)
 
 encodePerms :: PermissionActionSet -> B.Builder
 encodePerms =

--- a/src/Graph.hs
+++ b/src/Graph.hs
@@ -213,10 +213,10 @@ callMapFromNameMap :: NameMap -> CallMap
 callMapFromNameMap = Map.mapWithKey fromEntry
   where
     fromEntry name (pos, mDef, permissions) = let
-      calls = maybe Nop fromFunction mDef
-      in (pos, simplifyCallTree calls, permissions)
+      calls = maybe mempty fromFunction mDef
+      in (pos, calls, permissions)
 
-    fromFunction :: CFunDef -> CallTree Ident
+    fromFunction :: CFunDef -> CallSequence Ident
     fromFunction (CFunDef specifiers
       (CDeclr (Just ident@(Ident name _ pos)) _ _ _ _)
       parameters body _)
@@ -230,76 +230,76 @@ callMapFromNameMap = Map.mapWithKey fromEntry
             <- parameterDeclarations
           ]
 
-    fromFunction _ = Nop
+    fromFunction _ = mempty
 
-    fromStatement :: CStat -> CallTree Ident
+    fromStatement :: CStat -> CallSequence Ident
     fromStatement = \ case
       CLabel _label stat _attrs _pos
         -> fromStatement stat
       CCase expr stat _pos
         -> fromExpression expr
-        `Sequence` fromStatement stat
+        <> fromStatement stat
       CCases expr1 expr2 stat _pos
         -> fromExpression expr1
-        `Sequence` fromExpression expr2
-        `Sequence` fromStatement stat
+        <> fromExpression expr2
+        <> fromStatement stat
       CDefault stat _pos
         -> fromStatement stat
       CExpr mExpr _pos
-        -> maybe Nop fromExpression mExpr
+        -> foldMap fromExpression mExpr
       CCompound _localLabels blockItems _pos
-        -> foldr Sequence Nop $ map fromBlockItem blockItems
+        -> foldMap fromBlockItem blockItems
       CIf expr stat1 mStat2 _pos
         -> fromExpression expr
-        `Sequence` (fromStatement stat1 `Choice` maybe Nop fromStatement mStat2)
+        <> singletonCallSequence (fromStatement stat1 `Choice` foldMap fromStatement mStat2)
       -- | switch statement @CSwitch selectorExpr switchStmt@, where
       -- @switchStmt@ usually includes /case/, /break/ and /default/
       -- statements
       CSwitch expr stat _pos
         -> fromExpression expr
-        `Sequence` fromStatement stat
+        <> fromStatement stat
       CWhile expr stat isDoWhile _pos
-        | isDoWhile -> fromStatement stat `Sequence` fromExpression expr
-        | otherwise -> fromExpression expr `Sequence` fromStatement stat
+        | isDoWhile -> fromStatement stat <> fromExpression expr
+        | otherwise -> fromExpression expr <> fromStatement stat
       CFor mExpr1OrDecl mExpr2 mExpr3 stat _pos
-        -> either (maybe Nop fromExpression) fromDeclaration mExpr1OrDecl
-        `Sequence` maybe Nop fromExpression mExpr2
-        `Sequence` maybe Nop fromExpression mExpr3
-        `Sequence` fromStatement stat
+        -> either (foldMap fromExpression) fromDeclaration mExpr1OrDecl
+        <> foldMap fromExpression mExpr2
+        <> foldMap fromExpression mExpr3
+        <> fromStatement stat
 
       -- TODO: Do something more clever with flow control statements?
       CGoto _label _pos
-        -> Nop
+        -> mempty
       CGotoPtr expr _pos
         -> fromExpression expr
       CCont _pos
-        -> Nop
+        -> mempty
       CBreak _pos
-        -> Nop
+        -> mempty
       CReturn mExpr a
-        -> maybe Nop fromExpression mExpr
+        -> foldMap fromExpression mExpr
 
       -- TODO: Handle effects for assembly statements?
       CAsm _asmStat _pos
-        -> Nop
+        -> mempty
 
     -- This assumes a left-to-right evaluation order for binary expressions and
     -- function arguments, which is standard-compliant but not necessarily the
     -- same as what your compiler does.
 
-    fromExpression :: CExpr -> CallTree Ident
+    fromExpression :: CExpr -> CallSequence Ident
     fromExpression = \ case
       CComma exprs _pos
-        -> foldr Sequence Nop $ map fromExpression exprs
+        -> foldMap fromExpression exprs
       CAssign _op expr1 expr2 _pos
         -> fromExpression expr1
-        `Sequence` fromExpression expr2
+        <> fromExpression expr2
       CCond expr1 mExpr2 expr3 _pos
         -> fromExpression expr1
-        `Sequence` (maybe Nop fromExpression mExpr2 `Choice` fromExpression expr3)
+        <> singletonCallSequence (foldMap fromExpression mExpr2 `Choice` fromExpression expr3)
       CBinary _op expr1 expr2 _pos
         -> fromExpression expr1
-        `Sequence` fromExpression expr2
+        <> fromExpression expr2
       -- I'm pretty sure nothing needs to be done with the declaration here.
       CCast _decl expr _pos
         -> fromExpression expr
@@ -308,66 +308,66 @@ callMapFromNameMap = Map.mapWithKey fromEntry
       CSizeofExpr expr _pos
         -> fromExpression expr
       CSizeofType _decl _pos
-        -> Nop
+        -> mempty
       CAlignofExpr expr _pos
         -> fromExpression expr
       CAlignofType _decl _pos
-        -> Nop
+        -> mempty
       CComplexReal expr _pos
         -> fromExpression expr
       CComplexImag expr _pos
         -> fromExpression expr
       CIndex expr1 expr2 _pos
         -> fromExpression expr1
-        `Sequence` fromExpression expr2
+        <> fromExpression expr2
       CCall (CVar name _) args _pos
-        -> foldr Sequence Nop (map fromExpression args)
-        `Sequence` Call name
+        -> foldMap fromExpression args
+        <> singletonCallSequence (Call name)
       CCall expr args _pos
-        -> foldr Sequence Nop (map fromExpression args)
-        `Sequence` fromExpression expr
+        -> foldMap fromExpression args
+        <> fromExpression expr
       CMember expr _name _deref _pos
         -> fromExpression expr
       CVar _name _pos
-        -> Nop
+        -> mempty
       CConst _const
-        -> Nop
+        -> mempty
       CCompoundLit _decl initList _pos
         -> fromInitList initList
       -- TODO: This should probably be a choice of the possible cases.
       CGenericSelection expr _cases _pos
-        -> Nop
+        -> mempty
       CStatExpr stat _pos
         -> fromStatement stat
       CLabAddrExpr _label _pos
-        -> Nop
+        -> mempty
       -- TODO: Handle permissions for builtins.
       CBuiltinExpr _builtin
-        -> Nop
+        -> mempty
 
-    fromBlockItem :: CBlockItem -> CallTree Ident
+    fromBlockItem :: CBlockItem -> CallSequence Ident
     fromBlockItem = \ case
       CBlockStmt stat -> fromStatement stat
       CBlockDecl decl -> fromDeclaration decl
       -- TODO: Handle nested functions?
-      CNestedFunDef _def -> Nop
+      CNestedFunDef _def -> mempty
 
-    fromDeclaration :: CDecl -> CallTree Ident
+    fromDeclaration :: CDecl -> CallSequence Ident
     fromDeclaration (CDecl _specs declarators _pos)
-      = foldr Sequence Nop
+      = mconcat
       [ fromInitializer initializer
       | (_, Just initializer, _) <- declarators
       ]
     fromDeclaration CStaticAssert{}
-      = Nop
+      = mempty
 
-    fromInitializer :: CInit -> CallTree Ident
+    fromInitializer :: CInit -> CallSequence Ident
     fromInitializer (CInitExpr expr _pos) = fromExpression expr
     fromInitializer (CInitList initList _pos) = fromInitList initList
 
-    fromInitList :: CInitList -> CallTree Ident
+    fromInitList :: CInitList -> CallSequence Ident
     fromInitList initList
-      = foldr Sequence Nop
+      = mconcat
       [ fromInitializer initializer
       | (_, initializer) <- initList
       ]

--- a/src/Graph.hs
+++ b/src/Graph.hs
@@ -15,7 +15,7 @@ import Data.List (foldl')
 import Data.Monoid ((<>))
 import Language.C.Data.Ident (Ident(..))
 import qualified Language.C.Data.Ident
-import Language.C.Syntax.AST -- *
+import Language.C.Syntax.AST -- \*
 import Types
 import qualified Data.HashSet as HashSet
 import qualified Data.Map as Map
@@ -252,7 +252,7 @@ callMapFromNameMap = Map.mapWithKey fromEntry
       CIf expr stat1 mStat2 _pos
         -> fromExpression expr
         <> singletonCallSequence (fromStatement stat1 `Choice` foldMap fromStatement mStat2)
-      -- | switch statement @CSwitch selectorExpr switchStmt@, where
+      -- switch statement @CSwitch selectorExpr switchStmt@, where
       -- @switchStmt@ usually includes /case/, /break/ and /default/
       -- statements
       CSwitch expr stat _pos

--- a/src/ParseCallMap.hs
+++ b/src/ParseCallMap.hs
@@ -17,6 +17,7 @@ import Text.Parsec.Text.Lazy
 import qualified Data.HashSet as HashSet
 import qualified Data.Map as Map
 import qualified Data.ByteString.Lazy  as BSL
+import qualified Data.Sequence as Sequence
 import qualified Data.Text as Text
 import qualified Data.Text.Lazy as TextL
 import qualified Data.Text.Lazy.Encoding as TextL
@@ -131,7 +132,7 @@ calltreeForm :: Parser (CallSequence Ident)
 calltreeForm = theForm "calltree" seqForest
 
 seqForest :: Parser (CallSequence Ident)
-seqForest = CallSequence <$> many subcallForm
+seqForest = (CallSequence . Sequence.fromList) <$> many subcallForm
 
 subcallForm :: Parser (CallTree Ident)
 subcallForm =

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -22,7 +22,7 @@ import GHC.Generics (Generic)
 import Language.C.Data.Ident (Ident(..))
 import Language.C.Data.Node (NodeInfo(..))
 import Language.C.Data.Position (posFile, posRow)
-import Language.C.Syntax.AST -- *
+import Language.C.Syntax.AST -- \*
 import qualified Language.C.Parser as CParser
 import qualified Data.Map as Map
 import qualified Data.Sequence as Sequence
@@ -190,7 +190,7 @@ type CallMap = Map Ident (NodeInfo, CallSequence Ident, PermissionActionSet)
 data CallTree a
   = Choice !(CallSequence a) !(CallSequence a)
   | Call !a
-  -- | Abort  - the Monoid identity for 'CallTree' with respect to the 'Choice' operator
+  -- Abort  - the Monoid identity for 'CallTree' with respect to the 'Choice' operator
   deriving (Eq, Foldable, Functor, Traversable)
 
 newtype CallSequence a

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -8,10 +8,12 @@
 
 module Types where
 
+import Algebra.Algebra
 import Control.Concurrent.Chan (Chan, writeChan)
 import Control.Monad.IO.Class (MonadIO(..))
 import Data.Foldable (fold)
 import Data.HashSet (HashSet)
+import Data.HashMap.Strict (HashMap)
 import Data.Hashable (Hashable(..))
 import Data.Map (Map)
 import Data.Monoid ((<>), Endo(..))
@@ -24,6 +26,7 @@ import Language.C.Data.Node (NodeInfo(..))
 import Language.C.Data.Position (posFile, posRow)
 import Language.C.Syntax.AST -- \*
 import qualified Language.C.Parser as CParser
+import qualified Data.HashMap.Strict as HashMap
 import qualified Data.Map as Map
 import qualified Data.Sequence as Sequence
 import qualified Data.Text as Text
@@ -105,45 +108,194 @@ type PermissionActionSet = HashSet PermissionAction
 -- used during permission checking, inferred from 'PermissionAction's and the
 -- 'CallTree' of each function.
 --
--- * @'Has' p@: This call site has access to permission @p@. This appears when a
+-- The permission information present at each site is a product of two
+-- lattices: the 'Usage' lattice and the 'Capability' lattice.
+--
+-- Usage tracks the intrinsic consumption of permissions (ie, those call sites
+-- that make use of a permission (e.g. a call to lock a mutex intrinsically
+-- uses the lock permission).  Usage is a simple binary lattice:
+--
+-- @
+--               Uses
+--                |
+--                |
+--            UsageUnknown (==bottom)
+-- @
+--
+-- Capability tracks the potential to make use of a permisson.
+--
+-- * @'CapHas'@: This call site has access to permission @p@. This appears when a
 --   call @need@s @p@, before it @revoke@s @p@, or after it @grant@s @p@.
 --
--- * @'Uses' p@: This call site makes use of permission @p@.
---
--- * @'Lacks' p@: This call site does not have access to permission @p@. This
+-- * @'CapLacks'@: This call site does not have access to permission @p@. This
 --   appears after a call @revoke@s @p@, or before it @grant@s @p@.
 --
--- * @'Conflicts' p@: This call site was inferred to have conflicting
+-- * @'CapConflict'@: This call site was inferred to have conflicting
 --   information about @p@, that is, both 'Has' and 'Lacks' were inferred. All
 --   'Conflicts' are reported as errors after checking.
+-- * @'CapUnknown'@: We don't know anything about this call site yet.
 --
-data PermissionPresence
-  = Has !PermissionName
-  | Uses !PermissionName
-  | Lacks !PermissionName
-  | Conflicts !PermissionName
-  deriving (Eq, Generic, Ord)
-
+-- Capability forms a diamon lattice:
+--
+-- @
+--             CapConflict (== top)
+--              /      \\
+--             /        \\
+--         CapHas     CapLacks
+--             \\        /
+--              \\      /
+--             CapUnknown (== bottom)
+-- @
+--
+--
+-- 'PermissionPresence' is a product 'BoundedJoinSemiLattice' (ie, @'bottom' ==
+-- 'PermissionPresence' bottom bottom@, similarly for top, and meets and joins
+-- are taken componentwise.)
+data PermissionPresence = PermissionPresence
+  { presenceUsage :: !Usage
+  , presenceCapability :: !Capability
+  }
+  deriving (Eq, Generic)
 
 instance Show PermissionPresence where
-  show = \ case
-    Has p -> concat ["has(", show p, ")"]
-    Uses p -> concat ["uses(", show p, ")"]
-    Lacks p -> concat ["lacks(", show p, ")"]
-    Conflicts p -> concat ["conflicts(", show p, ")"]
+  show p =
+    let
+      showUsage UsageUnknown = ""
+      showUsage Uses = "&uses"
+    in case p of
+      PermissionPresence UsageUnknown CapHas -> "has"
+      PermissionPresence Uses CapHas -> "uses"
+      PermissionPresence u CapLacks -> "lacks" ++ showUsage u
+      PermissionPresence u CapConflict -> "conflicts" ++ showUsage u
+      PermissionPresence u CapUnknown -> "unknown" ++ showUsage u
+
+instance JoinSemiLattice PermissionPresence where
+  PermissionPresence u c \/ PermissionPresence u' c' = PermissionPresence (u \/ u') (c \/ c')
+
+instance BoundedJoinSemiLattice PermissionPresence where
+  bottom = PermissionPresence bottom bottom
+
+instance MeetSemiLattice PermissionPresence where
+  PermissionPresence u c /\ PermissionPresence u' c' = PermissionPresence (u /\ u') (c /\ c')
+
+-- | See 'PermissionPresence'
+data Usage = UsageUnknown | Uses
+  deriving (Eq, Ord, Generic, Show)
+
+instance JoinSemiLattice Usage where
+  (\/) = max
+
+instance BoundedJoinSemiLattice Usage where
+  bottom = UsageUnknown
+
+instance MeetSemiLattice Usage where
+  (/\) = min
+
+-- | See 'PermisisonPresence'
+data Capability = CapUnknown | CapHas | CapLacks | CapConflict
+  deriving (Eq, Generic, Show)
+
+instance JoinSemiLattice Capability where
+  c          \/ c' | c == c' = c
+  CapUnknown \/ c            = c
+  c          \/ CapUnknown   = c
+  _          \/ _            = CapConflict
+
+instance BoundedJoinSemiLattice Capability where
+  bottom = CapUnknown
+
+instance MeetSemiLattice Capability where
+  c           /\ c' | c == c' = c
+  CapConflict /\ c            = c
+  c           /\ CapConflict  = c
+  _           /\ _            = CapUnknown
+
+
+instance PartialOrd Usage where
+  leq = joinLeq
+
+instance PartialOrd Capability where
+  leq = joinLeq
+
+instance PartialOrd PermissionPresence where
+  leq = joinLeq
+
+instance Hashable Usage
+
+instance Hashable Capability
 
 instance Hashable PermissionPresence
 
--- | A set of permission presences; each call site has one of these.
---
-type PermissionPresenceSet = HashSet PermissionPresence
+has :: PermissionPresence
+has = PermissionPresence bottom CapHas
 
-presencePermission :: PermissionPresence -> PermissionName
-presencePermission = \ case
-  Has p -> p
-  Uses p -> p
-  Lacks p -> p
-  Conflicts p -> p
+lacks :: PermissionPresence
+lacks = PermissionPresence bottom CapLacks
+
+uses :: PermissionPresence
+uses = PermissionPresence Uses bottom
+
+conflicts :: PermissionPresence
+conflicts = PermissionPresence bottom CapConflict
+
+-- | Convenience function for testing whether we found a conflict.
+conflicting :: PermissionPresence -> Bool
+conflicting p = presenceCapability p == CapConflict
+
+-- | A mapping from permission names to permission presences; each call site
+-- has one of these.
+--
+-- The 'PermissionPresenceSet' enjoys a lattice structure that derives
+-- pointwise from the lattice structucture on 'PermissonPresence' - the order
+-- is given by keyset inclusion and when keys are present in both maps, the
+-- corresponding values must be ordered with respect to the
+-- 'PermissionPresence' 'PartialOrd'.  The bottom element is the empty set.
+--
+-- (Note we don't derive 'Monoid' instances because the underlying 'HashMap'
+-- 'Monoid' instance has a non-commutative ('<>') operation which we never want
+-- to use - we always want ('\/'))
+newtype PermissionPresenceSet =
+  PermissionPresenceSet
+  {
+    unPermissionPresenceSet :: HashMap PermissionName PermissionPresence
+  }
+  deriving (Eq, JoinSemiLattice, BoundedJoinSemiLattice)
+
+-- | Given a 'PermissionName' look up its presence in the given
+-- 'PermissionPresenceSet' or 'bottom' if its not in the set.
+lookupPresence :: PermissionName -> PermissionPresenceSet -> PermissionPresence
+lookupPresence pn = HashMap.lookupDefault bottom pn . unPermissionPresenceSet
+
+-- | Given a 'PermissionName' and a modification function,
+-- update the 'PermissionPresenceSet' with the modified presence.
+-- 
+-- * If the presence was previously not in the set, the modification function will be passed 'bottom'.
+-- * If the modification function returns 'bottom', the element is /not/ removed.
+modifyPresence :: PermissionName -> (PermissionPresence -> PermissionPresence) -> PermissionPresenceSet -> PermissionPresenceSet
+modifyPresence pn f =
+  PermissionPresenceSet . HashMap.alter f' pn . unPermissionPresenceSet
+  where
+    f' Nothing = Just $ f bottom
+    f' (Just p) = Just $ f p
+
+-- | Construct a 'PermissionPresenceSet' mapping the single element 
+singletonPresence
+  :: PermissionName -> PermissionPresence -> PermissionPresenceSet
+singletonPresence pn = PermissionPresenceSet . HashMap.singleton pn
+
+-- | Get the 'PermisionName's from the given 'PermissionPresenceSet
+presenceKeys :: PermissionPresenceSet -> [PermissionName]
+presenceKeys = HashMap.keys . unPermissionPresenceSet
+
+-- | Keep just the 'conflicting' elements of the 'PermissionPresenceSet'
+conflictingPresence :: PermissionPresenceSet -> PermissionPresenceSet
+conflictingPresence =
+  PermissionPresenceSet . HashMap.filter conflicting . unPermissionPresenceSet
+
+-- | Return @True@ iff the given 'PermissionPresenceSet' is empty.
+nullPresence :: PermissionPresenceSet -> Bool
+nullPresence = HashMap.null . unPermissionPresenceSet
+
 
 --------------------------------------------------------------------------------
 -- Call graphs
@@ -212,9 +364,9 @@ viewlCallSequence (CallSequence ts) =
 -- | Traverse the @CallTree a@ elements of a @CallSequence b@
 --
 -- This is a @Traversal@ in the sense of the lens library (although we do not depend on lens)
--- @@@
+-- @
 --   callTreesOfCallSequence :: Traversal (CallSequence a) (CallSequence b) (CallTree a) (CallTree b)
--- @@@
+-- @
 callTreesOfCallSequence :: Applicative f => (CallTree a -> f (CallTree b)) -> CallSequence a -> f (CallSequence b)
 callTreesOfCallSequence f (CallSequence ts) = CallSequence <$> traverse f ts
 
@@ -464,7 +616,7 @@ instance Monoid Declaration where
 -- restriction is reported along with the human-readable /description/ if any.
 --
 data Restriction = Restriction
-  { restCondition :: !PermissionPresence
+  { restName :: !PermissionName
   , restExpression :: !Expression
   , restDescription :: !(Maybe Description)
   }
@@ -482,8 +634,9 @@ instance Show Restriction where
     Nothing -> implication
     where
       implication = concat
-        [ show $ restCondition r
-        , " -> "
+        [ "uses("
+        , show $ restName r
+        , ") -> "
         , show $ restExpression r
         ]
 
@@ -491,7 +644,7 @@ instance Show Restriction where
 -- the context ('Context') or a combination of these using Boolean operations
 -- 'And', 'Or', and 'Not'.
 data Expression
-  = Context !PermissionPresence
+  = Context !PermissionName !PermissionPresence
   | !Expression `And` !Expression
   | !Expression `Or` !Expression
   | Not !Expression
@@ -502,11 +655,11 @@ infixr 3 `And`
 infixr 2 `Or`
 
 instance IsString Expression where
-  fromString = Context . Has . fromString
+  fromString = flip Context has . fromString
 
 instance Show Expression where
   showsPrec p = \ case
-    Context presence -> shows presence
+    Context nm presence -> shows presence . showParen True (shows nm)
     a `And` b -> showParen (p > andPrec)
       $ showsPrec andPrec a . showString " & " . showsPrec andPrec b
     a `Or` b -> showParen (p > orPrec)

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -204,7 +204,7 @@ spec = do
           (unlines $ "expected permission error but got:" : map show errors)
           $ case errors of
             [ (_, "restriction \"cannot take foo lock while bar lock is held\" (uses(lock_foo) -> !has(bar_locked)) violated in 'locks_wrong_nesting' at \"lock_bar\"")
-              , (_, "conflicting information for permissions [foo_locked,lock_foo] in 'locks_foo_recursively'")
+              , (_, "conflicting information for permissions [lock_foo,foo_locked] in 'locks_foo_recursively'")
               , (_, "restriction \"cannot take foo lock recursively\" (uses(lock_foo) -> !has(foo_locked)) violated in 'locks_foo_recursively' before first call")
               , (_, "restriction \"cannot take foo lock recursively\" (uses(lock_foo) -> !has(foo_locked)) violated in 'locks_foo_recursively' at \"lock_foo\"")
               , (_, "missing required annotation on 'missing_foo_locked'; annotation [] is missing: [need(foo_locked)]")


### PR DESCRIPTION
I should probably split this up into multiple PRs

1. A few more refactoring commits to break up the permission analysis functions.
2. Switch from 'CallTree' to a 'Sequence' of 'CallTree's ie represent the straight-line sections using a separate datatype instead of a binary `Seq` constructor  (and then flip from lists to `Data.Sequence.Seq`)
3.  Refactor the function that applies a `PermissionAction` at a `Site` to emphasize that it's mostly pure code
4. (The big one) Use a `BoundedJoinSemiLattice` as a representation of `PermissionPresence` (actually a product of a 2 elt lattice and of a discrete 2 element poset with added top and bottom) and then use a finite map to represent a `PermissionPresenceSet` (see commit message and comments).

After all that, the only change I had to make to the test was to switch the order of some strings that came out sorted differently.  Success