### PR TITLE
Fix renaming of statics

### DIFF
--- a/check-mono.sh
+++ b/check-mono.sh
@@ -47,6 +47,11 @@ function mtime() {
 	stat -f'%c' "$1"
 }
 
+function run_ward() {
+    #cabal run ward -- "$@"
+    stack exec ward -- "$@"
+}
+
 # Emit a graph file for each translation unit
 echo "Generating call graphs..." >&2
 for translation_unit in $translation_units; do
@@ -60,7 +65,7 @@ for translation_unit in $translation_units; do
 		echo "Call graph for $translation_unit is up to date" >&2
 	else
 		echo "Generating call graph for $translation_unit..." >&2
-		time stack exec ward \
+		time run_ward \
 			-- \
 			cc \
 			--mode=graph \
@@ -80,7 +85,7 @@ done
 
 # Check all graph files together
 echo "Checking call graphs..." >&2
-stack exec ward \
+run_ward \
 	-- \
 	cc \
 	--mode=compiler \

--- a/src/DumpCallMap.hs
+++ b/src/DumpCallMap.hs
@@ -81,7 +81,7 @@ encodeNodeInfo ni =
   else let
     position = encodePositionSpan (Node.posOfNode ni) (Node.getLastTokenPos ni)
     in case Node.nameOfNode ni of
-         Just name -> form "node" False (encodeName name <> position)
+         Just name -> form "node" False (encodeName name <> space <> position)
          Nothing -> form "onlypos" False position
 
 encodeName :: Name -> B.Builder


### PR DESCRIPTION
Look for *declarations* of static functions, not just *definitions* - both when identifying the set of statics in a translation unit, and also when doing the patching.

Closes #12 