### PR TITLE
Start using language-c >= 0.7

### DIFF
--- a/Ward.cabal
+++ b/Ward.cabal
@@ -29,7 +29,7 @@ executable ward
                      , containers
                      , filepath
                      , hashable
-                     , language-c >= 0.6
+                     , language-c >= 0.7
                      , optparse-applicative
                      , parsec
                      , pretty

--- a/src/DumpCallMap.hs
+++ b/src/DumpCallMap.hs
@@ -102,6 +102,11 @@ encodePositionSpan pstart pl
       in form "span" False $ mconcat $ intersperse space body
 
 -- N.B. Assumes Pos.isSourcePos would return True
+--
+-- TODO: Since language-c 0.7 we can now also get the include stack via
+-- 'Pos.posParent' which may be useful for error messages for static inline
+-- functions.  For now we don't both emiting it (or consuming it in
+-- "ParseCallMap").
 encodeSourcePos :: Pos.Position -> B.Builder
 encodeSourcePos p =
   let

--- a/src/ParseCallMap.hs
+++ b/src/ParseCallMap.hs
@@ -211,7 +211,7 @@ sourceForm =
     intlit = extractSpan <$> intLiteral
   in theForm "source" sourceBody
   where
-    mkPos path offset row column = CPos.position offset path row column
+    mkPos path offset row column = CPos.position offset path row column Nothing
 
 ------------------------------------------------------------
 -- Parsing S-expression files


### PR DESCRIPTION
The Language.C.Data.Position.Position data type changed (it now includes a
stack of include files), which required changes to callgraph saving and
loading.  For now we simply ignore the include stack when saving the call
graphs.  This will result in somewhat suboptimal error messages for static
inline functions or when we need to report something about function
declarations.

Additionally the test suite has been made less strict when checking that
roundtripping a callgraph to a file works as expected: we now ignore NodeInfo
details except the starting token file, row and column.