### PR TITLE
Force some graph computations to reduce space leaks

### DIFF
--- a/Ward.cabal
+++ b/Ward.cabal
@@ -27,6 +27,7 @@ executable ward
                      , array
                      , bytestring
                      , containers
+                     , deepseq
                      , filepath
                      , hashable
                      , language-c >= 0.7.1
@@ -58,6 +59,7 @@ test-suite test
                      , array
                      , bytestring
                      , containers
+                     , deepseq
                      , hashable
                      , hspec
                      , language-c

--- a/Ward.cabal
+++ b/Ward.cabal
@@ -30,7 +30,7 @@ executable ward
                      , deepseq
                      , filepath
                      , hashable
-                     , language-c >= 0.7.1
+                     , language-c >= 0.7.2
                      , optparse-applicative
                      , parsec
                      , pretty

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,6 @@
-resolver: nightly-2017-03-15
+resolver: lts-11.7
 packages:
 - '.'
-extra-deps:
-- language-c-0.7.1
+extra-deps: []
 flags: {}
 extra-package-dbs: []


### PR DESCRIPTION
I think we're holding on to multiple versions of the parsed C code because: 1. we're not forcing the static function name rewrites, 2. we're not forcing the call graph construction, so we get a lazy graph that keeps all the parsed C code in memory.

Next version of language-c will have DeepSeq instances for the entire AST, but until then let's just force as much as we can